### PR TITLE
Update to go 1.22 and golangci-lint 1.60.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
       - name: make-test
         run: make test
       - name: make-lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,3 @@
-run:
-  skip-dirs-use-default: false
 linters-settings:
   errcheck:
     check-type-assertions: true
@@ -23,31 +21,27 @@ linters:
   enable-all: true
   disable:
     - cyclop            # covered by gocyclo
-    - deadcode          # abandoned
-    - exhaustivestruct  # replaced by exhaustruct
+    - depguard          # unnecessary for small programs
+    - err113            # don't _always_ need to wrap errors
+    - execinquery       # deprecated in golangci v1.58
     - exhaustruct       # not useful for this repo (we want to rely on zero values for fields)
     - funlen            # rely on code review to limit function length
     - gocognit          # dubious "cognitive overhead" quantification
     - gofumpt           # prefer standard gofmt
     - goimports         # rely on gci instead
-    - golint            # deprecated by Go team
     - gomnd             # some unnamed constants are okay
-    - ifshort           # deprecated by author
-    - interfacer        # deprecated by author
     - ireturn           # "accept interfaces, return structs" isn't ironclad
     - lll               # don't want hard limits for line length
     - maintidx          # covered by gocyclo
-    - maligned          # readability trumps efficient struct packing
+    - mnd               # unnecessary for small programs
     - nlreturn          # generous whitespace violates house style
     - nonamedreturns    # named returns are fine, it's *bare* returns that are not
-    - nosnakecase       # deprecated in https://github.com/golangci/golangci-lint/pull/3065
-    - scopelint         # deprecated by author
-    - structcheck       # abandoned
+    - protogetter       # too many false positives
     - testpackage       # internal tests are fine
-    - varcheck          # abandoned
     - wrapcheck         # don't _always_ need to wrap errors
     - wsl               # generous whitespace violates house style
 issues:
+  exclude-dirs-use-default: false
   exclude:
     # Don't ban use of fmt.Errorf to create new errors, but the remaining
     # checks from err113 are useful.

--- a/Makefile
+++ b/Makefile
@@ -82,4 +82,4 @@ $(BIN)/license-header: Makefile
 
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
-	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.0
+	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bufbuild/knit-demo
 
-go 1.21.0
+go 1.22
 
 require (
 	buf.build/gen/go/bufbuild/knit-demo/connectrpc/go v1.15.0-20231005145018-a92ee6b04e01.1

--- a/go/internal/cmd/gendata/main.go
+++ b/go/internal/cmd/gendata/main.go
@@ -122,7 +122,7 @@ func printItems[T any](varName string, items []*T) {
 		fmt.Println("\t\t{")
 		v := reflect.ValueOf(item).Elem()
 		vt := v.Type()
-		for i := 0; i < v.NumField(); i++ {
+		for i := range v.NumField() {
 			fmt.Printf("\t\t\t%s: ", vt.Field(i).Name)
 			printItem(v.Field(i).Interface())
 			fmt.Println(",")

--- a/go/internal/server.go
+++ b/go/internal/server.go
@@ -16,10 +16,10 @@ package internal
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -102,7 +102,7 @@ func (i *interceptWriter) Write(bytes []byte) (int, error) {
 
 func (i *interceptWriter) WriteHeader(statusCode int) {
 	if !i.alreadyWrote {
-		i.status = fmt.Sprintf("%d", statusCode)
+		i.status = strconv.Itoa(statusCode)
 	}
 	i.w.WriteHeader(statusCode)
 }


### PR DESCRIPTION
Now that a new version of Go has been released, this bumps the versions used in this repo.

This also updates golangci-lint to the latest, which called for some config changes to eliminate warnings.