### PR TITLE
Fix err113 config in golanglint-ci

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,7 +22,6 @@ linters:
   disable:
     - cyclop            # covered by gocyclo
     - depguard          # unnecessary for small programs
-    - err113            # don't _always_ need to wrap errors
     - execinquery       # deprecated in golangci v1.58
     - exhaustruct       # not useful for this repo (we want to rely on zero values for fields)
     - funlen            # rely on code review to limit function length
@@ -45,7 +44,7 @@ issues:
   exclude:
     # Don't ban use of fmt.Errorf to create new errors, but the remaining
     # checks from err113 are useful.
-    - "err113: do not define dynamic errors.*"
+    - "do not define dynamic errors.*"
   exclude-rules:
     - path: cmd/.*/main\.go
       linters:


### PR DESCRIPTION
Just realized that we already had config to ignore the noisy checks, so I needed to fix that instead of ignoring err113 entirely.