### PR TITLE
Use go 1.23 to build docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.1-alpine AS builder
+FROM golang:1.23.8-alpine AS builder
 
 WORKDIR /workspace
 


### PR DESCRIPTION
I think this should fix the current issue on `main`: https://github.com/bufbuild/knit-demo/actions/runs/14517625303/job/40730426089#step:6:244

